### PR TITLE
Fix BASE URL

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,7 +1,7 @@
 // constants.js
-//export const BASE_URL = 'https://scan-dine-backend-5qms.onrender.com' 
+export const BASE_URL = 'https://scan-dine-backend-5qms.onrender.com' 
 //export const BASE_URL = 'http://13.127.209.255:8080'
-export const BASE_URL = 'http://localhost:8080'
+//export const BASE_URL = 'http://localhost:8080'
 export const USER_URL = '/api/v1/user'
 export const RESTAURANT_URL = '/api/v1/restaurant'
 export const ORDER_URL = '/api/v1'


### PR DESCRIPTION
This pull request makes a small yet important change to the `BASE_URL` configuration in `frontend/src/constants.js`. The change updates the active `BASE_URL` to point to the production backend, ensuring the application connects to the correct environment.

* [`frontend/src/constants.js`](diffhunk://#diff-0eb593e76f49e7df919220dac508eacce6d5477b9ebab86832f0f69bbeb028bcL2-R4): Activated the production `BASE_URL` (`https://scan-dine-backend-5qms.onrender.com`) by uncommenting it and commented out the local development URL (`http://localhost:8080`).